### PR TITLE
Issue with update + insert in PDO mysql driver

### DIFF
--- a/src/AbstractPdo.php
+++ b/src/AbstractPdo.php
@@ -151,12 +151,17 @@ abstract class AbstractPdo extends AbstractCache
                             ? implode(', ', $tags)
                             : null;
 
-        // upsert
-        $sql = $this->getSql('update');
-        $nb = $this->exec($sql, $values)->rowCount();
-        if ($nb == 0) {
-            $sql = $this->getSql('insert');
+        if (!empty($this->sql_definitions['upsert'])) {
+            $sql = $this->getSql('upsert');
             $nb = $this->exec($sql, $values)->rowCount();
+        } else {
+            // upsert
+            $sql = $this->getSql('update');
+            $nb = $this->exec($sql, $values)->rowCount();
+            if ($nb == 0) {
+                $sql = $this->getSql('insert');
+                $nb = $this->exec($sql, $values)->rowCount();
+            }
         }
 
         return (boolean) $nb;

--- a/src/Pdo/Mysql.php
+++ b/src/Pdo/Mysql.php
@@ -43,11 +43,10 @@ class Mysql extends AbstractPdo
                         (`expire` IS NULL OR `expire` > :now);',
         'update'    => 'UPDATE `%s` SET `data`=:data, `tags`=:tags, `expire`=:exp,
                         `dated`=:dated WHERE `key`=:key;',
-        'insert'    => 'INSERT INTO `%s` (`key`, `data`, `tags`, `expire`, `dated`)
-                        VALUES (:key, :data, :tags, :exp, :dated);',
-        'upsert'    => 'INSERT INTO `%s` (`key`, `data`, `tags`, `expire`, `dated`)
-                        VALUES (:key, :data, :tags, :exp, :dated)
-                        ON DUPLICATE KEY UPDATE `data`=VALUES(`data`),`tags`=VALUES(`tags`),`expire`=VALUES(`expire`);',
+        'insert'    => 'INSERT INTO `%s` (`key`, `data`, `tags`, `expire`,
+                        `dated`) VALUES (:key, :data, :tags, :exp, :dated)
+                        ON DUPLICATE KEY UPDATE `data`=VALUES(`data`),
+                        `tags`=VALUES(`tags`), `expire`=VALUES(`expire`);',
         'delete'    => 'DELETE FROM `%s` WHERE `key`=?;',
         'clean'     => 'DELETE FROM `%s` WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',

--- a/src/Pdo/Mysql.php
+++ b/src/Pdo/Mysql.php
@@ -45,6 +45,9 @@ class Mysql extends AbstractPdo
                         `dated`=:dated WHERE `key`=:key;',
         'insert'    => 'INSERT INTO `%s` (`key`, `data`, `tags`, `expire`, `dated`)
                         VALUES (:key, :data, :tags, :exp, :dated);',
+        'upsert'    => 'INSERT INTO `%s` (`key`, `data`, `tags`, `expire`, `dated`)
+                        VALUES (:key, :data, :tags, :exp, :dated)
+                        ON DUPLICATE KEY UPDATE `data`=VALUES(`data`),`tags`=VALUES(`tags`),`expire`=VALUES(`expire`);',
         'delete'    => 'DELETE FROM `%s` WHERE `key`=?;',
         'clean'     => 'DELETE FROM `%s` WHERE %s;', // %s 'clean_like' iterated
         'clean_like'=> 'tags LIKE ?',

--- a/tests/PdoTest.php
+++ b/tests/PdoTest.php
@@ -200,7 +200,16 @@ class PdoTest extends GenericTestCase
         }
     }
 
-    public function testSameKeyData() {
+    /**
+     * Regression test for pull request GH#28
+     *
+     * @link https://github.com/frqnck/apix-cache/pull/28
+     *  PDOException: SQLSTATE[23000]: Integrity constraint violation:
+     *  1062 Duplicate entry 'apix-cache-key:same_key' for key 'PRIMARY'
+     * @group pr
+     */
+    public function testPullRequest28()
+    {
         $this->cache->save('same_data', 'same_key');
         $this->cache->save('same_data', 'same_key');
 

--- a/tests/PdoTest.php
+++ b/tests/PdoTest.php
@@ -200,4 +200,10 @@ class PdoTest extends GenericTestCase
         }
     }
 
+    public function testSameKeyData() {
+        $this->cache->save('same_data', 'same_key');
+        $this->cache->save('same_data', 'same_key');
+
+        $this->assertEquals('same_data', $this->cache->load('same_key'));
+    }
 }


### PR DESCRIPTION
When same data is stored under same key PDO mysql driver return 0 number of updated rows and as a result insert triggers error "SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry"

MySQL has a special SQL extension INSERT ON DUPLICATE KEY UPDATE which can be used instead of UPDATE + INSERT.

