### PR TITLE
Fix: `Files::flush(true)` does not work

### DIFF
--- a/src/Files.php
+++ b/src/Files.php
@@ -237,7 +237,7 @@ class Files extends AbstractCache
             $fullKey = base64_decode($file);
             $key = $this->removePrefixKey($fullKey);
 
-            if (!$all && ($key !== $fullKey || '' === $this->options['prefix_key'])) {
+            if ($all || (!$all && ($key !== $fullKey || '' === $this->options['prefix_key']))) {
                 unlink($path);
             }
         }

--- a/tests/FilesTest.php
+++ b/tests/FilesTest.php
@@ -58,6 +58,16 @@ class FilesTest extends GenericTestCase
         file_put_contents($this->cache->getOption('directory').DIRECTORY_SEPARATOR.$encoded, PHP_EOL);
         $this->assertNull($this->cache->loadKey('id'));
     }
+	
+	public function testFlushAll()
+	{
+		$this->cache->save('testdata1', 'id1', array('tag1', 'tag2'));
+		$this->cache->save('testdata2', 'id2', array('tag3', 'tag4'));
+		$this->assertEquals(2, $this->getDirectoryFileCount($this->dir));
+		
+		$this->cache->flush(true);
+		$this->assertEquals(0, $this->getDirectoryFileCount($this->dir));
+	}
 
     /**
      * Regression test for pull request GH#17
@@ -79,5 +89,10 @@ class FilesTest extends GenericTestCase
         // for good measure.
         $this->assertFalse($this->cache->clean(array('tag2')));
     }
+		
+	private function getDirectoryFileCount($folder){
+		$iterator = new \FilesystemIterator($folder, \FilesystemIterator::SKIP_DOTS);
+		return iterator_count($iterator);
+	}
 
 }


### PR DESCRIPTION
<!--
1. Please check the Contributing Guidelines: https://github.com/frqnck/apix-cache/blob/master/.github/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
-->

## What did you implement:

**Implementing Issue:** #1234

<!-- Briefly describe the feature if no issue exists for this PR. -->

## How did you implement it:

<!-- Please briefly describe your implementation. -->

## How can we verify it:

<!-- Please provide any applicable commands or other resources to make it easy for us to verify this works. -->

## Done and todos:

<!-- Please tick with [x] as appropriate. -->

- [ ] Write unit tests,
- [ ] Write documentation,
- [ ] Fix linting errors,
- [ ] Make sure code coverage hasn't dropped,
- [ ] Leave a comment that this is ready for review once you've finished the implementation.
