### PR TITLE
Modified Redis::flush to delete all keys only from the current DB

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -133,7 +133,7 @@ class Redis extends AbstractCache
     public function flush($all=false)
     {
         if (true === $all) {
-            return $this->adapter->flushAll();
+            return $this->adapter->flushDb();
         }
         $items = array_merge(
             $this->adapter->keys($this->mapTag('*')),


### PR DESCRIPTION
## What did you implement:
Redis has a less often used feature to isolate key spaces into up to 16 databases. By default, if not otherwise explicitly set, database 0 is used - which is the normal use-case for most users. 

Apix uses the Redis instance passed in the configuration, with whatever database selected. It does not handle in any way database changes (nor it shouldn't). However, in the `flush` method, instead of deleting all keys from current db, it empties all redis, even other databases that were out of reach when getting/setting keys using the `flushAll` method on phpredis. Normally, the `flushDb` method should be used, which just empties the currently selected db (which is 0 for most users anyway).

How I reached this conclusion?
In our current setup we have set up our session provider to use database 0. And Apix to use database 1. This way using the same Redis instance for both use-cases, while isolating the 2 key-spaces. This works fine, until we do a `$pool->clear();` which erases both its keys and all sessions at the same time.

## How can we verify it:

1. Add keys to both databases 0 and 1
2. When configuring the Redis instance, after connecting, just do a `$redis->select(1);` before instantiating the Pool. 
3. Do a clear cache => expectation: only keys in db 1 should be deleted

## Done and todos:

<!-- Please tick with [x] as appropriate. -->

- [ ] Write unit tests,
- [ ] Write documentation,
- [x] Fix linting errors,
- [x] Make sure code coverage hasn't dropped,
- [x] Leave a comment that this is ready for review once you've finished the implementation.
