### PR TITLE
Added cas_token to getTtl() method.

### DIFF
--- a/src/Memcached.php
+++ b/src/Memcached.php
@@ -395,10 +395,13 @@ class Memcached extends AbstractCache
      * {@inheritdoc}
      *
      * The number of seconds may not exceed 60*60*24*30 = 2,592,000 (30 days).
+     * 
+     * @param string $key       The cache key to retrieve.
+     * @param float  $cas_token The variable to store the CAS token in.
      *
      * @see http://php.net/manual/en/memcached.expiration.php
      */
-    public function getTtl($key)
+    public function getTtl($key, &$cas_token = null)
     {
         $mKey = $this->mapKey($key);
 


### PR DESCRIPTION
<!--
1. Please check the Contributing Guidelines: https://github.com/frqnck/apix-cache/blob/master/.github/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
-->

## What did you implement:
Added $cas_token as a parameter to getTtl() method.

The getTtl() method has a reference to $cas_token which wasn't defined.

## How did you implement it:
Added $cas_token as a parameter to getTtl() method.

## How can we verify it:
Code review

## Done and todos:

<!-- Please tick with [x] as appropriate. -->

- [ ] Write unit tests,
- [x] Write documentation,
- [ ] Fix linting errors,
- [ ] Make sure code coverage hasn't dropped,
- [ ] Leave a comment that this is ready for review once you've finished the implementation.
