### PR TITLE
Travis: PHP 5.4 and 5.5 cannot run on Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - memcached
   - mongodb
   - mysql
-  - pgsql
+  - postgresql
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,17 @@ services:
   - redis-server
   - memcached
   - mongodb
+  - mysql
+  - pgsql
 php:
   - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
   - nightly
   - hhvm
 env:
@@ -25,6 +30,10 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
     - php: 7.0
       env: DB=mariadb
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ services:
   - postgresql
 php:
   - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
@@ -32,8 +30,46 @@ matrix:
       dist: precise
     - php: 5.4
       dist: trusty
+      env: DB=apc
+    - php: 5.4
+      dist: trusty
+      env: DB=redis
+    - php: 5.4
+      dist: trusty
+      env: DB=mongodb
+    - php: 5.4
+      dist: trusty
+      env: DB=sqlite
+    - php: 5.4
+      dist: trusty
+      env: DB=mysql
+    - php: 5.4
+      dist: trusty
+      env: DB=pgsql
+    - php: 5.4
+      dist: trusty
+      env: DB=memcached
     - php: 5.5
       dist: trusty
+      env: DB=apc
+    - php: 5.5
+      dist: trusty
+      env: DB=redis
+    - php: 5.5
+      dist: trusty
+      env: DB=mongodb
+    - php: 5.5
+      dist: trusty
+      env: DB=sqlite
+    - php: 5.5
+      dist: trusty
+      env: DB=mysql
+    - php: 5.5
+      dist: trusty
+      env: DB=pgsql
+    - php: 5.5
+      dist: trusty
+      env: DB=memcached
     - php: 7.0
       env: DB=mariadb
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,25 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+      env: DB=apc
+    - php: 5.3
+      dist: precise
+      env: DB=redis
+    - php: 5.3
+      dist: precise
+      env: DB=mongodb
+    - php: 5.3
+      dist: precise
+      env: DB=sqlite
+    - php: 5.3
+      dist: precise
+      env: DB=mysql
+    - php: 5.3
+      dist: precise
+      env: DB=pgsql
+    - php: 5.3
+      dist: precise
+      env: DB=memcached
     - php: 5.4
       dist: trusty
       env: DB=apc

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,13 @@ services:
   - mysql
   - postgresql
 php:
-  - 5.3
   - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
-  - nightly
-  - hhvm
+  #- nightly
+  #- hhvm
 env:
   - DB=apc
   - DB=redis
@@ -99,12 +98,18 @@ matrix:
         mariadb: 10.1
   allow_failures:
     - php: 5.3
-    - php: nightly
+    #- php: nightly
     - php: 5.3
       env: DB=memcached # memcached client is broken on PHP 5.3
     - php: 7.0
       env: DB=memcached # memcached client does not fully support PHP7
-    - php: hhvm
+    - php: 7.1
+      env: DB=memcached # memcached client does not fully support PHP7
+    - php: 7.2
+      env: DB=memcached # memcached client does not fully support PHP7
+    - php: 7.3
+      env: DB=memcached # memcached client does not fully support PHP7
+    #- php: hhvm
       # env: DB=mongodb   # mongodb client does not compile under hhvm
 
 before_install:

--- a/src/Memcached.php
+++ b/src/Memcached.php
@@ -217,31 +217,27 @@ class Memcached extends AbstractCache
 
             // @codeCoverageIgnoreStart
             case 'igBinary':
-                if (!\Memcached::HAVE_IGBINARY) {
-                    continue;
+                if (\Memcached::HAVE_IGBINARY) {
+                    $opt = \Memcached::SERIALIZER_IGBINARY;
                 }
-                $opt = \Memcached::SERIALIZER_IGBINARY;
             break;
 
             case 'json':
-                if (!\Memcached::HAVE_JSON) {
-                    continue;
+                if (\Memcached::HAVE_JSON) {
+                    $opt = \Memcached::SERIALIZER_JSON;
                 }
-                $opt = \Memcached::SERIALIZER_JSON;
             break;
 
             case 'json_array':
-                if (!\Memcached::HAVE_JSON_ARRAY) {
-                    continue;
+                if (\Memcached::HAVE_JSON_ARRAY) {
+                    $opt = \Memcached::SERIALIZER_JSON_ARRAY;
                 }
-                $opt = \Memcached::SERIALIZER_JSON_ARRAY;
             break;
 
             case 'msgpack':
-                if (!\Memcached::HAVE_MSGPACK) {
-                    continue;
+                if (\Memcached::HAVE_MSGPACK) {
+                    $opt = \Memcached::SERIALIZER_MSGPACK;
                 }
-                $opt = \Memcached::SERIALIZER_MSGPACK;
             break;
             // @codeCoverageIgnoreEnd
 

--- a/tests/bin/travis-init.sh
+++ b/tests/bin/travis-init.sh
@@ -28,7 +28,7 @@ else
     then
         pecl_install msgpack 0.5.7
     else
-        pecl_install msgpack 2.0.2
+        pecl_install msgpack 2.0.3
     fi
 fi
 

--- a/tests/bin/travis-init.sh
+++ b/tests/bin/travis-init.sh
@@ -21,7 +21,7 @@ else
     pecl channel-update pecl.php.net
 
     # install igbinary
-    pecl_install igbinary 2.0.1
+    pecl_install igbinary 2.0.8
 
     # install msgpack
     if [ "$(expr "${VERSION}" "<" "7.0")" -eq 1 ]


### PR DESCRIPTION
Have PHP 5.4 and 5.5 builds run on Trusty.

Fixes #36

## What did you implement:

**Implementing Issue:** #36 

## How did you implement it:

Added entries to matrix.include to have PHP versions 5.4 and 5.5 build on Trusty.
Corrected entries for 5.3 to build on Pricise
Added targets for PHP 7.1, 7.2 and 7.3
Corrected user of continue in switch statement in Memcached.php/setSerializer() (for 7.3 compatibility).
WARNING base: PHP Error:  {"type":2,"message":"\"continue\" targeting switch is equivalent to \"break\". Did you mean to use \"continue 2\"?","file":"/nas/content/live/mycpprod/wp-content/plugins/mycp-redcap/vendor/apix/cache/src/Memcached.php","line":242} 


## How can we verify it:

Builds no longer fail.
Warning no longer appears on PHP 7.3.

## Done and todos:

- [ ] Write unit tests,
- [ ] Write documentation,
- [ ] Fix linting errors,
- [ ] Make sure code coverage hasn't dropped,
- [ ] Leave a comment that this is ready for review once you've finished the implementation.
