### PR TITLE
Use break instead of continue in Memcached.php

### DIFF
--- a/src/Memcached.php
+++ b/src/Memcached.php
@@ -218,28 +218,28 @@ class Memcached extends AbstractCache
             // @codeCoverageIgnoreStart
             case 'igBinary':
                 if (!\Memcached::HAVE_IGBINARY) {
-                    continue;
+                    break;
                 }
                 $opt = \Memcached::SERIALIZER_IGBINARY;
             break;
 
             case 'json':
                 if (!\Memcached::HAVE_JSON) {
-                    continue;
+                    break;
                 }
                 $opt = \Memcached::SERIALIZER_JSON;
             break;
 
             case 'json_array':
                 if (!\Memcached::HAVE_JSON_ARRAY) {
-                    continue;
+                    break;
                 }
                 $opt = \Memcached::SERIALIZER_JSON_ARRAY;
             break;
 
             case 'msgpack':
                 if (!\Memcached::HAVE_MSGPACK) {
-                    continue;
+                    break;
                 }
                 $opt = \Memcached::SERIALIZER_MSGPACK;
             break;


### PR DESCRIPTION
When using continue within switch, PHP triggers a warning:
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in vendor/apix/cache/src/Memcached.php on line 228

<!--
1. Please check the Contributing Guidelines: https://github.com/frqnck/apix-cache/blob/master/.github/CONTRIBUTING.md
2. Fill out the whole template so we have a good overview on the issue
3. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
-->

## What did you implement:

I replaced "continue" with "break". The function still does the same.