### PR TITLE
AbstractPdo::loadKey() generating Notice

### DIFF
--- a/src/AbstractPdo.php
+++ b/src/AbstractPdo.php
@@ -107,12 +107,12 @@ abstract class AbstractPdo extends AbstractCache
 
         $cached = $this->exec($sql, $values)->fetch();
 
-        // if (isset($cached['expire'])) {
+        if (false !== $cached) {
             $this->ttls[$key] = $cached['expire'];
-        // }
 
-        if (null !== $cached['data'] && null !== $this->serializer) {
-            return $this->serializer->unserialize($cached['data']);
+            if (null !== $cached['data'] && null !== $this->serializer) {
+                return $this->serializer->unserialize($cached['data']);
+            }
         }
 
         return false === $cached ? null : $cached['data'];

--- a/tests/PdoTest.php
+++ b/tests/PdoTest.php
@@ -308,4 +308,36 @@ class PdoTest extends GenericTestCase
 
         $this->assertEquals('same_data', $this->cache->load('same_key'));
     }
+
+    /**
+     * @requires PHP 7.3
+     */
+    public function testCacheMiss_loadKey()
+    {
+        $cacheMissKey = 'CacheMissKey';
+
+        try {
+            $result = $this->cache->loadKey($cacheMissKey);
+
+            $this->assertNull($result);
+        } catch (\Exception $e) {
+            $this->fail('Exception should not have been thrown');
+        }
+    }
+
+    /**
+     * @requires PHP 7.3
+     */
+    public function testCacheMiss_loadTag()
+    {
+        $cacheMissTag = 'CacheMissTag';
+
+        try {
+            $result = $this->cache->loadTag($cacheMissTag);
+
+            $this->assertNull($result);
+        } catch (\Exception $e) {
+            $this->fail('Exception should not have been thrown');
+        }
+    }
 }


### PR DESCRIPTION
On PHP >= 7.3, if the key passed to loadKey() isn't in the cache a notice is generated because value returned from PDO::fetch() is false but it is treated as an array.

## How did you implement it:
Add check for false result returned from fetch().

## How can we verify it:

Unit tests

## Done and todos:

- [x] Write unit tests,
- [ ] Write documentation,
- [ ] Fix linting errors,
- [x] Make sure code coverage hasn't dropped,
- [x] Leave a comment that this is ready for review once you've finished the implementation.
